### PR TITLE
Add exit code

### DIFF
--- a/AirISP/BasicOperation.cs
+++ b/AirISP/BasicOperation.cs
@@ -75,7 +75,7 @@ namespace AirISP
                 catch (Exception ex)
                 {
                     ColorfulConsole.WarnLine($"{(Tool.IsZh() ? "打开串口失败" : "Failed to open serial port")}: {ex.Message}");
-                    Environment.Exit(0);
+                    Environment.Exit(2);
                     return false;
                 }
                 return true;
@@ -239,7 +239,7 @@ namespace AirISP
                 "你可以尝试手动进入boot模式：\r\n" +
                 "拔掉USB、按住BOOT按键不要松开、插入USB，重新尝试下载操作。\r\n" +
                 "下载完成后，再松开松开BOOT按键，此时再按一下RST复位即可。" : "fail to reset device to boot status, timeout, exit...");
-            Environment.Exit(0);
+            Environment.Exit(1);
             return false;
         }
 

--- a/AirISP/WriteFlash.cs
+++ b/AirISP/WriteFlash.cs
@@ -44,7 +44,7 @@ namespace AirISP
                     break;
                 default:
                     ColorfulConsole.WarnLine($"Please enter the correct filename.");
-                    Environment.Exit(0);
+                    Environment.Exit(3);
                     return false;
             }
 
@@ -87,7 +87,7 @@ namespace AirISP
                 if (BasicOperation.Write(command, 500) == false)
                 {
                     ColorfulConsole.WarnLine($"prepare writing to address 0x{now:X} failed.");
-                    return false;
+                    Environment.Exit(4);
                 }
                 var addrBytes = new byte[5] {
                     (byte)(now/256/256/256),
@@ -103,7 +103,7 @@ namespace AirISP
                 if (BasicOperation.Write(addrBytes) == false)
                 {
                     ColorfulConsole.WarnLine($"set write address 0x{now:X} failed.");
-                    return false;
+                    Environment.Exit(4);
                 }
 
                 var flashData = new byte[1 + 128 + 1];
@@ -118,7 +118,7 @@ namespace AirISP
                 if (BasicOperation.Write(flashData, 500) == false)
                 {
                     ColorfulConsole.WarnLine($"writing to address 0x{now:X} failed.");
-                    return false;
+                    Environment.Exit(4);
                 }
 
                 now += 0x80;

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Air001-ISP
 An ISP tool for Air001
+
+Compatible with Arduino IDE 2.x and VScode Arduino plugin known. 
+
+Some of errors have their exitcode. You can see the table in exitcode.txt. 

--- a/exitcode.txt
+++ b/exitcode.txt
@@ -1,0 +1,5 @@
+0 - normal
+1 - no ACK recieved. see https://wiki.luatos.com/chips/air001/mcu.html#id4
+2 - Failed to open serial port
+3 - file does not exit
+4 - writing failed. 


### PR DESCRIPTION
In version 1.2.7.0, there won't be any output in VScode Arduino plugin even upload failed. Only `[Done] Uploading sketch 'air001.ino'`(VScode) or *Done uploading.* (Arduino IDE) was displayed. 

In this pr, output will show *failed uploading* and a exit code when failed to upload. 